### PR TITLE
Adding jshintrc to root, whoops

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,65 @@
+{
+    // Settings
+    "passfail" : true, // Stop on first error.
+    "maxerr" : 100, // Maximum errors before stopping.
+
+    // Predefined globals whom JSHint will ignore.
+    "browser" : true, // Standard browser globals e.g. `window`, `document`.
+
+    "node" : false,
+    "rhino" : false,
+    "couch" : false,
+
+    "jquery" : false,
+    "prototypejs" : false,
+    "mootools" : false,
+    "dojo" : false,
+
+    "predef" : [ // Extra globals.
+        "ShaderParticleGroup",
+        "ShaderParticleEmitter",
+        "shaderParticleUtils",
+        "THREE"
+    ],
+
+    // Development.
+    "debug" : false, // Allow debugger statements e.g. browser breakpoints.
+    "devel" : true, // Allow development statements e.g. `console.log();`.
+
+    // EcmaScript 5.
+    "es5" : false, // Allow EcmaScript 5 syntax.
+    "strict" : false, // Require `use strict` pragma in every file.
+    "globalstrict" : false, // Allow global "use strict" (also enables 'strict').
+
+    // The Good Parts.
+    "asi" : false, // Tolerate Automatic Semicolon Insertion (no semicolons).
+    "laxbreak" : true, // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
+    "bitwise" : false, // Prohibit bitwise operators (&, |, ^, etc.).
+    "boss" : true, // Tolerate assignments inside if, for & while. Usually conditions & loops are for comparison, not assignments.
+    "curly" : true, // Require {} for every new block or scope.
+    "eqeqeq" : false, // Require triple equals i.e. `===`.
+    "eqnull" : false, // Tolerate use of `== null`.
+    "evil" : true, // Tolerate use of `eval`.
+    "expr" : true, // Tolerate `ExpressionStatement` as Programs.
+    "forin" : false, // Tolerate `for in` loops without `hasOwnPrototype`.
+    "immed" : true, // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
+    "latedef" : true, // Prohibit variable use before definition.
+    "loopfunc" : true, // Allow functions to be defined within loops.
+    "noarg" : true, // Prohibit use of `arguments.caller` and `arguments.callee`.
+    "regexp" : false, // Prohibit `.` and `[^...]` in regular expressions.
+    "regexdash" : false, // Tolerate unescaped last dash i.e. `[-...]`.
+    "scripturl" : true, // Tolerate script-targeted URLs.
+    "shadow" : false, // Allows re-define variables later in code e.g. `var x=1; x=2;`.
+    "supernew" : false, // Tolerate `new function () { ... };` and `new Object;`.
+    "undef" : true, // Require all non-global variables be declared before they are used.
+
+    // Persone styling prefrences.
+    "newcap" : true, // Require capitalization of all constructor functions e.g. `new F()`.
+    "noempty" : true, // Prohibit use of empty blocks.
+    "nonew" : true, // Prohibit use of constructors for side-effects.
+    "nomen" : false, // Prohibit use of initial or trailing underbars in names.
+    "onevar" : false, // Allow only one `var` statement per function.
+    "plusplus" : false, // Prohibit use of `++` & `--`.
+    "sub" : false, // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
+    "trailing" : true // Prohibit trailing whitespaces.
+}


### PR DESCRIPTION
This should have been in the original jshint PR. It defines the correct
globals so jshint doesn't yell at us when using THREE for example
