### PR TITLE
Fixed the total particle count in asteroid demo

### DIFF
--- a/examples/asteroid.html
+++ b/examples/asteroid.html
@@ -146,7 +146,7 @@
             scene.add( particleGroup.mesh );
 
             document.querySelector('.numParticles').textContent =
-                'Total particles: ' + emitter.numParticles;
+                'Total particles: ' + emitter.particleCount;
         }
 
         function updateCamera() {

--- a/examples/clouds.html
+++ b/examples/clouds.html
@@ -73,7 +73,7 @@
         	scene.add( particleGroup.mesh );
 
         	document.querySelector('.numParticles').textContent =
-        		'Total particles: ' + emitter.numParticles;
+        		'Total particles: ' + emitter.particleCount;
         }
 
 

--- a/examples/mouseFollow.html
+++ b/examples/mouseFollow.html
@@ -75,7 +75,7 @@
         	scene.add( particleGroup.mesh );
 
         	document.querySelector('.numParticles').textContent =
-        		'Total particles: ' + emitter.numParticles;
+        		'Total particles: ' + emitter.particleCount;
         }
 
 

--- a/examples/multipleEmitters.html
+++ b/examples/multipleEmitters.html
@@ -99,7 +99,7 @@
         	scene.add( particleGroup.mesh );
 
         	document.querySelector('.numParticles').textContent =
-        		'Total particles: ' + (emitter.numParticles * numEmitters);
+        		'Total particles: ' + (emitter.particleCount * numEmitters);
         }
 
 

--- a/examples/sandbox.html
+++ b/examples/sandbox.html
@@ -112,7 +112,7 @@
             scene.add( particleGroup.mesh );
 
             document.querySelector('.numParticles').textContent =
-                'Total particles: ' + emitter.numParticles;
+                'Total particles: ' + emitter.particleCount;
         }
 
 

--- a/examples/sphere.html
+++ b/examples/sphere.html
@@ -75,7 +75,7 @@
         	scene.add( particleGroup.mesh );
 
         	document.querySelector('.numParticles').textContent =
-        		'Total particles: ' + emitter.numParticles;
+        		'Total particles: ' + emitter.particleCount;
         }
 
 

--- a/examples/spherePulsing.html
+++ b/examples/spherePulsing.html
@@ -85,7 +85,7 @@
         	scene.add( particleGroup.mesh );
 
         	document.querySelector('.numParticles').textContent =
-        		'Total particles: ' + emitter.numParticles;
+        		'Total particles: ' + emitter.particleCount;
         }
 
 

--- a/examples/starfield.html
+++ b/examples/starfield.html
@@ -72,7 +72,7 @@
         	scene.add( particleGroup.mesh );
 
         	document.querySelector('.numParticles').textContent =
-        		'Total particles: ' + emitter.numParticles;
+        		'Total particles: ' + emitter.particleCount;
         }
 
 

--- a/examples/static.html
+++ b/examples/static.html
@@ -81,7 +81,7 @@
         	scene.add( particleGroup.mesh );
 
         	document.querySelector('.numParticles').textContent =
-        		'Total particles: ' + (emitter.numParticles * numEmitters);
+        		'Total particles: ' + (emitter.particleCount * numEmitters);
         }
 
 


### PR DESCRIPTION
The asteroid demo was using an undefined value (`emitter.numParticles') to display the number of particles being rendered, the result was the screen displaying "Total particles: undefined".

This commit fixes that by using the defined value: `emitter.particleCount' instead.