### PR TITLE
typescript definitions

### DIFF
--- a/src/ShaderParticleEmitter.js
+++ b/src/ShaderParticleEmitter.js
@@ -25,7 +25,7 @@ SPE.Emitter = function( options ) {
     that.position               = options.position instanceof THREE.Vector3 ? options.position : new THREE.Vector3();
     that.positionSpread         = options.positionSpread instanceof THREE.Vector3 ? options.positionSpread : new THREE.Vector3();
 
-    // These two properties are only used when this.type === 'sphere' or 'disk'
+    // These four properties are only used when this.type === 'sphere' or 'disk'
     that.radius                 = typeof options.radius === 'number' ? options.radius : 10;
     that.radiusSpread           = typeof options.radiusSpread === 'number' ? options.radiusSpread : 0;
     that.radiusScale            = options.radiusScale instanceof THREE.Vector3 ? options.radiusScale : new THREE.Vector3(1, 1, 1);

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,6 @@
+# TypeScript Definitions #
+
+Reference `ShaderParticles.d.ts` in your project. 
+
+- `ShaderParticles.d.ts` contains a reference to `three.d.ts` and so this file is required.
+- You can find `three.d.ts` [here in the DefinitelyTyped project](https://github.com/borisyankov/DefinitelyTyped/tree/master/threejs) on git hub.

--- a/typescript/ShaderParticles.d.ts
+++ b/typescript/ShaderParticles.d.ts
@@ -1,0 +1,95 @@
+/// <reference path="three.d.ts"/>
+
+// Type definitions for ShaderParticles Version 0.7.8
+// Project: https://github.com/squarefeet/ShaderParticleEngine
+
+declare module SPE {
+    class Group {
+        mesh:THREE.Mesh;
+
+        constructor(options:any);
+        addEmitter(particleEmitter:Emitter):Group;
+        removeEmitter(emitter);
+        getFromPool():Emitter;
+        releaseIntoPool(emitter:Emitter):Group;
+        addPool(numEmitters:number, emitterSettings:any, createNew:boolean):Group;
+        triggerPoolEmitter(numEmitters:number, position:THREE.Vector3):Group;
+        tick(dt:number);
+    }
+
+    class Emitter {
+        particleCount:number;
+        type:string;
+        position:THREE.Vector3;
+        positionSpread:THREE.Vector3;
+
+        // These four properties are only used when this.type === 'sphere' or 'disk'
+        radius:number;
+        radiusSpread:number;
+        radiusScale:THREE.Vector3;
+        radiusSpreadClamp:number;
+
+        acceleration:THREE.Vector3;
+        accelerationSpread:THREE.Vector3;
+
+        velocity:THREE.Vector3;
+        velocitySpread:THREE.Vector3;
+
+        // And again here; only used when this.type === 'sphere' or 'disk'
+        speed:number;
+        speedSpread:number;
+
+        // Sizes
+        sizeStart:number;
+        sizeStartSpread:number;
+
+        sizeEnd:number;
+        sizeEndSpread:number;
+
+        sizeMiddle:number;
+        sizeMiddleSpread:number;
+
+        // Angles
+        angleStart:number;
+        angleStartSpread:number;
+
+        angleEnd:number;
+        angleEndSpread:number;
+
+        angleMiddle:number;
+        angleMiddleSpread:number;
+        angleAlignVelocity:number;
+
+        // Colors
+        colorStart:THREE.Vector3;
+        colorStartSpread:THREE.Color;
+
+        colorEnd:THREE.Color;
+        colorEndSpread:THREE.Color;
+
+        colorMiddle:THREE.Color;
+        colorMiddleSpread:THREE.Vector3;
+
+        // Opacities
+        opacityStart:number;
+        opacityStartSpread:number;
+
+        opacityEnd:number;
+        opacityEndSpread:number;
+
+        opacityMiddle:number;
+        opacityMiddleSpread:number;
+
+        // Generic
+        duration:number;
+        alive:number;
+        isStatic:number;
+
+        userData:any;
+
+        constructor(options:any);
+        reset(force:boolean);
+        enable();
+        disable();
+    }
+}


### PR DESCRIPTION
this pullrequest contains the typescript definitons for the group and the emitter.
This enables typescript users to use the library by referencing the defintions and including the javascript.

also fixed a comment: the next four properties are disk/sphere only, not the next two.
noticed it when creating the typescript definitions.