### PR TITLE
Remove duplicate dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,5 @@
     "directories": {
         "doc": "docs",
         "example": "examples"
-    },
-    "dependencies": {
-        "grunt": "^0.4.5",
-        "grunt-contrib-concat": "^0.5.1",
-        "grunt-docco2": "^0.2.1",
-        "grunt-contrib-uglify": "^0.9.2",
-        "grunt-jsdoc": "^1.0.0"
     }
 }


### PR DESCRIPTION
Thank you for your great work!

I tried to use this engine with webpack, and found that there are some dependencies for development in package.json `dependencies` field, which is used for production environment. The same dependencies are already in `devDependencies`, so it seems to be safe to remove duplicate dependencies in `dependencies` field.