### PR TITLE
Removing use of global grunt and adding npm build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,9 @@ A massive improvement over the previous versions of this library is _actual docu
 
 Building
 --------
-This project uses [Grunt](http://gruntjs.com/) to create the distributions, one dev build (not minimized) and one production build (minimized). If you make changes and want to build it, follow these steps:
+This project uses [Grunt](http://gruntjs.com/) to create the distributions, one dev build (not minimized) and one production build (minimized). If you make changes and want to build it, run:
 
-If you don't have grunt installed, first make sure you've got [NodeJS](http://nodejs.org/) and NPM installed, then install Grunt CLI. You might have to do this as root:
-
-```npm install -g grunt-cli```
-
-Now you can install the local grunt package:
-
-```cd [projectFolder] && npm install && grunt```
+```npm run build```
 
 The output of grunt will sit in the `build` folder.
 

--- a/package.json
+++ b/package.json
@@ -1,39 +1,40 @@
 {
-    "name": "shader-particle-engine",
-    "description": "A GLSL-focused particle engine for THREE.js.",
-    "version": "1.0.3",
-    "author": "Luke Moody (https://github.com/squarefeet/)",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/squarefeet/ShaderParticleEngine.git"
-    },
-    "bugs": {
-        "url": "https://github.com/squarefeet/ShaderParticleEngine/issues"
-    },
-    "homepage": "https://github.com/squarefeet/ShaderParticleEngine/",
-    "keywords": [
-        "three.js",
-        "webgl",
-        "particle",
-        "particles",
-        "glsl",
-        "shader",
-        "spe"
-    ],
-    "devDependencies": {
-        "grunt": "^0.4.5",
-        "grunt-contrib-concat": "^0.5.1",
-        "grunt-contrib-uglify": "^0.9.2",
-        "grunt-docco2": "^0.2.1",
-        "grunt-jsdoc": "^1.0.0"
-    },
-    "scripts": {
-        "test": "grunt"
-    },
-    "main": "build/SPE.min.js",
-    "directories": {
-        "doc": "docs",
-        "example": "examples"
-    }
+  "name": "shader-particle-engine",
+  "description": "A GLSL-focused particle engine for THREE.js.",
+  "version": "1.0.3",
+  "author": "Luke Moody (https://github.com/squarefeet/)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/squarefeet/ShaderParticleEngine.git"
+  },
+  "bugs": {
+    "url": "https://github.com/squarefeet/ShaderParticleEngine/issues"
+  },
+  "homepage": "https://github.com/squarefeet/ShaderParticleEngine/",
+  "keywords": [
+    "three.js",
+    "webgl",
+    "particle",
+    "particles",
+    "glsl",
+    "shader",
+    "spe"
+  ],
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-concat": "^0.5.1",
+    "grunt-contrib-uglify": "^0.9.2",
+    "grunt-docco2": "^0.2.1",
+    "grunt-jsdoc": "^1.1.0"
+  },
+  "scripts": {
+    "build": "grunt"
+  },
+  "main": "build/SPE.min.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  }
 }


### PR DESCRIPTION
This is a minor modernization of the project. You shouldn't require
users to have global versions of packages installed. Using npm scripts
means the grunt command will be available when the npm script is run.

Note the indentation of package.json has changed to two spaces. This is
because of the use of the automatic command `npm install --save-dev
grunt`. Note any automatic npm command will change the spacing to 2
spaces, so I think it's best to keep it this way.

Additionally this adds missing grunt plugins to the packages, which
presumably you had installed along with your global grunt.
