### PR TITLE
Fix for `getFromPool()` when pool is empty.

### DIFF
--- a/src/core/SPE.Group.js
+++ b/src/core/SPE.Group.js
@@ -494,7 +494,11 @@ SPE.Group.prototype.getFromPool = function() {
         return pool.pop();
     }
     else if ( createNew ) {
-        return new SPE.Emitter( this._poolCreationSettings );
+        var emitter = new SPE.Emitter( this._poolCreationSettings );
+        
+        this.addEmitter( emitter );
+        
+        return emitter;
     }
 
     return null;


### PR DESCRIPTION
When trying to get an emitter from an empty pool, a new emitter is created when specified, but it is not added to this group like the emitters in `addPool` are. This change makes sure that any emitters created via this method will also automatically add to the group as one would expect.