### PR TITLE
Set initial color uniform for fog enabled groups (Fix for Three r104)

### DIFF
--- a/src/core/SPE.Group.js
+++ b/src/core/SPE.Group.js
@@ -134,7 +134,7 @@ SPE.Group = function( options ) {
         },
         fogColor: {
             type: 'c',
-            value: null
+            value: this.fog ? new THREE.Color() : null
         },
         fogNear: {
             type: 'f',


### PR DESCRIPTION
This change fixes fog that PR https://github.com/mrdoob/three.js/pull/15467 broke. Since color is now copied instead of being forcibly applied, a THREE.Color default value is necessary.