### PR TITLE
Update THREE.Math.generateUUID to THREE.MathUtils.generateUUID

### DIFF
--- a/src/core/SPE.Emitter.js
+++ b/src/core/SPE.Emitter.js
@@ -176,7 +176,7 @@ SPE.Emitter = function( options ) {
         console.warn( 'onParticleSpawn has been removed. Please set properties directly to alter values at runtime.' );
     }
 
-    this.uuid = THREE.Math.generateUUID();
+    this.uuid = THREE.MathUtils.generateUUID();
 
     this.type = utils.ensureTypedArg( options.type, types.NUMBER, SPE.distributions.BOX );
 

--- a/src/core/SPE.Group.js
+++ b/src/core/SPE.Group.js
@@ -68,7 +68,7 @@ SPE.Group = function( options ) {
     options.texture = utils.ensureTypedArg( options.texture, types.OBJECT, {} );
 
     // Assign a UUID to this instance
-    this.uuid = THREE.Math.generateUUID();
+    this.uuid = THREE.MathUtils.generateUUID();
 
     // If no `deltaTime` value is passed to the `SPE.Group.tick` function,
     // the value of this property will be used to advance the simulation.


### PR DESCRIPTION
Looks like THREE.Math got changed to THREE.MathUtils at r113.
https://github.com/mrdoob/three.js/wiki/Migration-Guide#r112--r113

This required a line change in SPE.Emitter and SPE.Group.